### PR TITLE
Adding ability to omit SDMX attributes

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -740,4 +740,239 @@ prose:
             label: "Other information"
             translation_key: metadata_fields.source_other_info_1
             scope: source_6
+            ######### National Metadata #########
+      - name: SDG_INDICATOR_INFO
+        field:
+            element: text
+            label: Indicator information
+            translation_key: metadata_fields.SDG_INDICATOR_INFO
+            scope: national
+      - name: SDG_GOAL
+        field:
+            element: text
+            label: Goal
+            translation_key: metadata_fields.SDG_GOAL
+            scope: national
+      - name: SDG_TARGET
+        field:
+            element: text
+            label: Target
+            translation_key: metadata_fields.SDG_TARGET
+            scope: national
+      - name: SDG_INDICATOR
+        field:
+            element: text
+            label: Indicator
+            translation_key: metadata_fields.SDG_INDICATOR
+            scope: national
+      - name: SDG_SERIES_DESCR
+        field:
+            element: text
+            label: Series
+            translation_key: metadata_fields.SDG_SERIES_DESCR
+            scope: national
+      - name: META_LAST_UPDATE
+        field:
+            element: text
+            label: Metadata update
+            translation_key: metadata_fields.META_LAST_UPDATE
+            scope: national
+      - name: SDG_RELATED_INDICATORS
+        field:
+            element: text
+            label: Related indicators
+            translation_key: metadata_fields.SDG_RELATED_INDICATORS
+            scope: national
+      - name: CONTACT
+        field:
+            element: text
+            label: Data reporter
+            translation_key: metadata_fields.CONTACT
+            scope: national
+      - name: CONTACT_ORGANISATION
+        field:
+            element: text
+            label: Organisation
+            translation_key: metadata_fields.CONTACT_ORGANISATION
+            scope: national
+      - name: CONTACT_NAME
+        field:
+            element: text
+            label: Contact person(s)
+            translation_key: metadata_fields.CONTACT_NAME
+            scope: national
+      - name: ORGANISATION_UNIT
+        field:
+            element: text
+            label: Contact organisation unit
+            translation_key: metadata_fields.ORGANISATION_UNIT
+            scope: national
+      - name: CONTACT_FUNCT
+        field:
+            element: text
+            label: Contact person function
+            translation_key: metadata_fields.CONTACT_FUNCT
+            scope: national
+      - name: CONTACT_PHONE
+        field:
+            element: text
+            label: Contact phone
+            translation_key: metadata_fields.CONTACT_PHONE
+            scope: national
+      - name: CONTACT_MAIL
+        field:
+            element: text
+            label: Contact mail
+            translation_key: metadata_fields.CONTACT_MAIL
+            scope: national
+      - name: CONTACT_EMAIL
+        field:
+            element: text
+            label: Contact email
+            translation_key: metadata_fields.CONTACT_EMAIL
+            scope: national
+      - name: IND_DEF_CON_CLASS
+        field:
+            element: text
+            label: Definition, concepts, and classifications
+            translation_key: metadata_fields.IND_DEF_CON_CLASS
+            scope: national
+      - name: STAT_CONC_DEF
+        field:
+            element: text
+            label: Definition and concepts
+            translation_key: metadata_fields.STAT_CONC_DEF
+            scope: national
+      - name: UNIT_MEASURE
+        field:
+            element: text
+            label: Unit of measure
+            translation_key: metadata_fields.UNIT_MEASURE
+            scope: national
+      - name: CLASS_SYSTEM
+        field:
+            element: text
+            label: Classifications
+            translation_key: metadata_fields.CLASS_SYSTEM
+            scope: national
+      - name: SRC_TYPE_COLL_METHOD
+        field:
+            element: text
+            label: Data source type and collection method
+            translation_key: metadata_fields.SRC_TYPE_COLL_METHOD
+            scope: national
+      - name: SOURCE_TYPE
+        field:
+            element: text
+            label: Data sources
+            translation_key: metadata_fields.SOURCE_TYPE
+            scope: national
+      - name: COLL_METHOD
+        field:
+            element: text
+            label: Data collection method
+            translation_key: metadata_fields.COLL_METHOD
+            scope: national
+      - name: FREQ_COLL
+        field:
+            element: text
+            label: Data collection calendar
+            translation_key: metadata_fields.FREQ_COLL
+            scope: national
+      - name: REL_CAL_POLICY
+        field:
+            element: text
+            label: Data release calendar
+            translation_key: metadata_fields.REL_CAL_POLICY
+            scope: national
+      - name: DATA_SOURCE
+        field:
+            element: text
+            label: Data providers
+            translation_key: metadata_fields.DATA_SOURCE
+            scope: national
+      - name: COMPILING_ORG
+        field:
+            element: text
+            label: Data compilers
+            translation_key: metadata_fields.COMPILING_ORG
+            scope: national
+      - name: INST_MANDATE
+        field:
+            element: text
+            label: Institutional mandate
+            translation_key: metadata_fields.INST_MANDATE
+            scope: national
+      - name: OTHER_METHOD
+        field:
+            element: text
+            label: Other methodological considerations
+            translation_key: metadata_fields.OTHER_METHOD
+            scope: national
+      - name: RATIONALE
+        field:
+            element: text
+            label: Rationale
+            translation_key: metadata_fields.RATIONALE
+            scope: national
+      - name: REC_USE_LIM
+        field:
+            element: text
+            label: Comment and limitations
+            translation_key: metadata_fields.REC_USE_LIM
+            scope: national
+      - name: DATA_COMP
+        field:
+            element: text
+            label: Method of computation
+            translation_key: metadata_fields.DATA_COMP
+            scope: national
+      - name: DATA_VALIDATION
+        field:
+            element: text
+            label: Validation
+            translation_key: metadata_fields.DATA_VALIDATION
+            scope: national
+      - name: DOC_METHOD
+        field:
+            element: text
+            label: Methods and guidance available to countries for the compilation of the data at the national level
+            translation_key: metadata_fields.DOC_METHOD
+            scope: national
+      - name: QUALITY_MGMNT
+        field:
+            element: text
+            label: Quality management
+            translation_key: metadata_fields.QUALITY_MGMNT
+            scope: national
+      - name: QUALITY_ASSURE
+        field:
+            element: text
+            label: Quality assurance
+            translation_key: metadata_fields.QUALITY_ASSURE
+            scope: national
+      - name: QUALITY_ASSMNT
+        field:
+            element: text
+            label: Quality assessment
+            translation_key: metadata_fields.QUALITY_ASSMNT
+            scope: national
+      - name: COVERAGE
+        field:
+            element: text
+            label: Data availability and disaggregation
+            translation_key: metadata_fields.COVERAGE
+            scope: national
+      - name: COMPARABILITY
+        field:
+            element: text
+            label: Comparability/deviation from international standards
+            translation_key: metadata_fields.COMPARABILITY
+            scope: national
+      - name: OTHER_DOC
+        field:
+            element: text
+            label: References and Documentation
+            translation_key: metadata_fields.OTHER_DOC
+            scope: national      
   ignore: ['/scripts', '/.github']


### PR DESCRIPTION
The pull requests adds the yml file from the data starter to be able to edit the national metadata forms input via macro word